### PR TITLE
enable users to comment and update tickets. 

### DIFF
--- a/backend/app/api/v1/tickets.py
+++ b/backend/app/api/v1/tickets.py
@@ -24,6 +24,36 @@ MANAGER_ROLES = (UserRole.home_admin, UserRole.global_admin)
 
 router = APIRouter(prefix="/tickets", tags=["tickets"])
 
+
+def _is_manager(user: User) -> bool:
+    return user.role in MANAGER_ROLES
+
+
+def _get_ticket_or_404(db: Session, ticket_id: int) -> models.Ticket:
+    ticket = db.query(models.Ticket).filter(models.Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return ticket
+
+
+def assert_ticket_participant(user: User, ticket: models.Ticket) -> None:
+    if _is_manager(user):
+        return
+    if user.role == UserRole.home_user and ticket.assignee_id == user.id:
+        return
+    raise HTTPException(status_code=403, detail="Forbidden")
+
+
+def assert_comment_editor(user: User, ticket: models.Ticket, comment: models.Comment) -> None:
+    if _is_manager(user):
+        return
+    if user.role == UserRole.home_user:
+        if ticket.assignee_id == user.id:
+            return
+        if comment.author and comment.author == user.username:
+            return
+    raise HTTPException(status_code=403, detail="Forbidden")
+
 def _ticket_query(db: Session):
     return db.query(models.Ticket).options(
         joinedload(models.Ticket.comments),
@@ -194,10 +224,8 @@ def add_ticket_comment(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, *MANAGER_ROLES)
-    exists = db.query(models.Ticket.id).filter(models.Ticket.id == ticket_id).first()
-    if not exists:
-        raise HTTPException(status_code=404, detail="Ticket not found")
+    ticket = _get_ticket_or_404(db, ticket_id)
+    assert_ticket_participant(current_user, ticket)
     comment = models.Comment(
         ticket_id=ticket_id,
         author=body.author,
@@ -216,7 +244,6 @@ def update_ticket_comment(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, *MANAGER_ROLES)
     comment = (
         db.query(models.Comment)
         .filter(models.Comment.id == comment_id, models.Comment.ticket_id == ticket_id)
@@ -224,6 +251,8 @@ def update_ticket_comment(
     )
     if not comment:
         raise HTTPException(status_code=404, detail="Comment not found")
+    ticket = comment.ticket or _get_ticket_or_404(db, ticket_id)
+    assert_comment_editor(current_user, ticket, comment)
     if body.author is not None:
         comment.author = body.author
     if body.text is not None:
@@ -257,10 +286,8 @@ def add_ticket_task(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, *MANAGER_ROLES)
-    exists = db.query(models.Ticket.id).filter(models.Ticket.id == ticket_id).first()
-    if not exists:
-        raise HTTPException(status_code=404, detail="Ticket not found")
+    ticket = _get_ticket_or_404(db, ticket_id)
+    assert_ticket_participant(current_user, ticket)
     max_pos = (
         db.query(models.Task.position)
         .filter(models.Task.ticket_id == ticket_id)
@@ -288,7 +315,6 @@ def update_ticket_task(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, *MANAGER_ROLES)
     task = (
         db.query(models.Task)
         .filter(models.Task.ticket_id == ticket_id, models.Task.id == task_id)
@@ -296,6 +322,8 @@ def update_ticket_task(
     )
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
+    ticket = task.ticket or _get_ticket_or_404(db, ticket_id)
+    assert_ticket_participant(current_user, ticket)
     if body.text is not None:
         task.text = body.text
     if body.eta is not None:

--- a/backend/tests/test_ticket_permissions.py
+++ b/backend/tests/test_ticket_permissions.py
@@ -1,0 +1,101 @@
+import os
+from typing import Optional
+
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.v1.tickets import add_ticket_comment
+from app.database import Base
+from app.models import Ticket
+from app.models.user import User, UserRole
+from app.schemas.ticket import CommentCreate, TicketStatus
+
+
+engine = create_engine(
+    "sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def _create_user(session, username: str, role: UserRole) -> User:
+    user = User(username=username, role=role, hashed_password="not-used")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _create_ticket(session, assignee_id: Optional[int]) -> Ticket:
+    ticket = Ticket(
+        title="Test Ticket",
+        description="",
+        status=TicketStatus.todo,
+        category=None,
+        room=None,
+        assignee_id=assignee_id,
+    )
+    session.add(ticket)
+    session.commit()
+    session.refresh(ticket)
+    return ticket
+
+
+def test_home_user_can_comment_on_assigned_ticket(db_session):
+    home_user = _create_user(db_session, "home", UserRole.home_user)
+    ticket = _create_ticket(db_session, home_user.id)
+
+    comment = add_ticket_comment(
+        ticket.id,
+        CommentCreate(author=home_user.username, text="My update"),
+        db=db_session,
+        current_user=home_user,
+    )
+
+    assert comment.text == "My update"
+    assert comment.author == home_user.username
+
+
+def test_home_user_denied_comment_on_unassigned_ticket(db_session):
+    home_user = _create_user(db_session, "home", UserRole.home_user)
+    other_user = _create_user(db_session, "other", UserRole.home_user)
+    ticket = _create_ticket(db_session, other_user.id)
+
+    with pytest.raises(HTTPException) as exc:
+        add_ticket_comment(
+            ticket.id,
+            CommentCreate(author=home_user.username, text="Should fail"),
+            db=db_session,
+            current_user=home_user,
+        )
+
+    assert exc.value.status_code == 403
+
+
+def test_manager_can_comment_on_any_ticket(db_session):
+    manager = _create_user(db_session, "manager", UserRole.global_admin)
+    other_user = _create_user(db_session, "other", UserRole.home_user)
+    ticket = _create_ticket(db_session, other_user.id)
+
+    comment = add_ticket_comment(
+        ticket.id,
+        CommentCreate(author=manager.username, text="Manager update"),
+        db=db_session,
+        current_user=manager,
+    )
+
+    assert comment.text == "Manager update"


### PR DESCRIPTION
Added ticket permission helpers to reuse participant checks and let assigned home users manage their ticket comments and tasks while retaining manager-only operations elsewhere.

Created unit tests that exercise comment creation permissions for home users and managers using an in-memory SQLite test session.

Testing

✅ pytest backend/tests