### PR TITLE
introduce user ownership metadata for ticket data

### DIFF
--- a/backend/app/api/v1/tickets.py
+++ b/backend/app/api/v1/tickets.py
@@ -104,14 +104,15 @@ def create_new_ticket(
     )
     db.add(ticket)
     db.flush()
+    next_task_pos = 0
     for c in body.comments:
         comment = models.Comment(
             ticket_id=ticket.id,
-            author=c.author,
+            author=c.author if c.author is not None else current_user.username,
+            author_id=current_user.id,
             text=c.text,
         )
         db.add(comment)
-        next_task_pos = 0
     for t in body.tasks:
         task = models.Task(
             ticket_id=ticket.id,
@@ -119,6 +120,7 @@ def create_new_ticket(
             eta=t.eta,
             completed=False,
             position=next_task_pos,
+            created_by_id=current_user.id,
         )
         db.add(task)
         next_task_pos += 1
@@ -200,7 +202,8 @@ def add_ticket_comment(
         raise HTTPException(status_code=404, detail="Ticket not found")
     comment = models.Comment(
         ticket_id=ticket_id,
-        author=body.author,
+        author=body.author if body.author is not None else current_user.username,
+        author_id=current_user.id,
         text=body.text,
     )
     db.add(comment)
@@ -216,7 +219,6 @@ def update_ticket_comment(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, *MANAGER_ROLES)
     comment = (
         db.query(models.Comment)
         .filter(models.Comment.id == comment_id, models.Comment.ticket_id == ticket_id)
@@ -224,6 +226,8 @@ def update_ticket_comment(
     )
     if not comment:
         raise HTTPException(status_code=404, detail="Comment not found")
+    if current_user.role not in MANAGER_ROLES and comment.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     if body.author is not None:
         comment.author = body.author
     if body.text is not None:
@@ -239,7 +243,6 @@ def delete_ticket_comment(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, *MANAGER_ROLES)
     comment = (
         db.query(models.Comment)
         .filter(models.Comment.id == comment_id, models.Comment.ticket_id == ticket_id)
@@ -247,6 +250,8 @@ def delete_ticket_comment(
     )
     if not comment:
         raise HTTPException(status_code=404, detail="Comment not found")
+    if current_user.role not in MANAGER_ROLES and comment.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     db.delete(comment)
     db.commit()
 
@@ -274,6 +279,7 @@ def add_ticket_task(
         eta=body.eta,
         completed=False,
         position=next_pos,
+        created_by_id=current_user.id,
     )
     db.add(task)
     db.commit()
@@ -288,7 +294,6 @@ def update_ticket_task(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, *MANAGER_ROLES)
     task = (
         db.query(models.Task)
         .filter(models.Task.ticket_id == ticket_id, models.Task.id == task_id)
@@ -296,6 +301,8 @@ def update_ticket_task(
     )
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
+    if current_user.role not in MANAGER_ROLES and task.created_by_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     if body.text is not None:
         task.text = body.text
     if body.eta is not None:
@@ -315,7 +322,6 @@ def delete_ticket_task(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, *MANAGER_ROLES)
     task = (
         db.query(models.Task)
         .filter(models.Task.ticket_id == ticket_id, models.Task.id == task_id)
@@ -323,6 +329,8 @@ def delete_ticket_task(
     )
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
+    if current_user.role not in MANAGER_ROLES and task.created_by_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     db.delete(task)
     db.commit()
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -31,9 +31,20 @@ class Comment(Base):
     id = Column(Integer, primary_key=True, index=True)
     ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
     author = Column(String(100), nullable=True)
+    author_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     text = Column(Text, nullable=False)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     ticket = relationship("Ticket", back_populates="comments")
+    author_user = relationship(
+        "User",
+        back_populates="comments",
+        foreign_keys="Comment.author_id",
+    )
 
 class Task(Base):
     __tablename__ = "tasks"
@@ -43,5 +54,16 @@ class Task(Base):
     completed = Column(Boolean, nullable=False, default=False)
     eta = Column(DateTime, nullable=True)
     position = Column(Integer, nullable=False, default=0)
+    created_by_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     ticket = relationship("Ticket", back_populates="tasks")
+    created_by = relationship(
+        "User",
+        back_populates="created_tasks",
+        foreign_keys="Task.created_by_id",
+    )
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -49,10 +49,20 @@ class Comment(Base):
         index=True,
     )
     author = Column(String(100), nullable=True)
+    author_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     text = Column(Text, nullable=False)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     ticket = relationship("Ticket", back_populates="comments")
-
+    author_user = relationship(
+        "User",
+        back_populates="comments",
+        foreign_keys="Comment.author_id",
+    )
 
 class Task(Base):
     __tablename__ = "tasks"
@@ -67,7 +77,18 @@ class Task(Base):
     completed = Column(Boolean, nullable=False, default=False)
     eta = Column(DateTime, nullable=True)
     position = Column(Integer, nullable=False, default=0)
+    created_by_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     ticket = relationship("Ticket", back_populates="tasks")
+    created_by = relationship(
+        "User",
+        back_populates="created_tasks",
+        foreign_keys="Task.created_by_id",
+    )
 
 
 from .user import User, UserRole

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -32,3 +32,13 @@ class User(Base):
         back_populates="assignee",
         foreign_keys="Ticket.assignee_id",
     )
+    comments = relationship(
+        "Comment",
+        back_populates="author_user",
+        foreign_keys="Comment.author_id",
+    )
+    created_tasks = relationship(
+        "Task",
+        back_populates="created_by",
+        foreign_keys="Task.created_by_id",
+    )

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -25,6 +25,7 @@ class CommentUpdate(BaseModel):
 class CommentRead(CommentBase):
     id: int
     created_at: datetime
+    author_id: Optional[int] = None
 
     model_config = {"from_attributes": True}
 
@@ -45,6 +46,7 @@ class TaskRead(TaskBase):
     id: int
     completed: bool
     position: int
+    created_by_id: Optional[int] = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/migrations/versions/5f3f7f8dd4ef_add_comment_and_task_owners.py
+++ b/backend/migrations/versions/5f3f7f8dd4ef_add_comment_and_task_owners.py
@@ -1,0 +1,85 @@
+"""Add author/creator tracking to comments and tasks."""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5f3f7f8dd4ef"
+down_revision: Union[str, Sequence[str], None] = "c0f269813939"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "comments",
+        sa.Column("author_id", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_comments_author_id"), "comments", ["author_id"], unique=False
+    )
+    op.create_foreign_key(
+        "fk_comments_author_id_users",
+        "comments",
+        "users",
+        ["author_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column(
+        "tasks",
+        sa.Column("created_by_id", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_tasks_created_by_id"), "tasks", ["created_by_id"], unique=False
+    )
+    op.create_foreign_key(
+        "fk_tasks_created_by_id_users",
+        "tasks",
+        "users",
+        ["created_by_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    comments = sa.table(
+        "comments",
+        sa.column("id", sa.Integer()),
+        sa.column("author", sa.String()),
+        sa.column("author_id", sa.Integer()),
+    )
+    users = sa.table(
+        "users",
+        sa.column("id", sa.Integer()),
+        sa.column("username", sa.String()),
+    )
+
+    bind = op.get_bind()
+    user_rows = bind.execute(sa.select(users.c.username, users.c.id)).all()
+    username_to_id = {row.username: row.id for row in user_rows}
+
+    if username_to_id:
+        comment_rows = bind.execute(sa.select(comments.c.id, comments.c.author)).all()
+        for comment_id, author in comment_rows:
+            if author:
+                user_id = username_to_id.get(author)
+                if user_id:
+                    bind.execute(
+                        sa.update(comments)
+                        .where(comments.c.id == comment_id)
+                        .values(author_id=user_id)
+                    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_tasks_created_by_id_users", "tasks", type_="foreignkey")
+    op.drop_index(op.f("ix_tasks_created_by_id"), table_name="tasks")
+    op.drop_column("tasks", "created_by_id")
+
+    op.drop_constraint("fk_comments_author_id_users", "comments", type_="foreignkey")
+    op.drop_index(op.f("ix_comments_author_id"), table_name="comments")
+    op.drop_column("comments", "author_id")


### PR DESCRIPTION
Added author_id and created_by_id ownership columns to comment and task models and linked them back to the User model.

Surfaced owner identifiers in the comment/task response schemas and enforced owner-or-admin authorization for comment/task updates and deletions while setting ownership on creation.

Introduced an Alembic migration that creates the new foreign keys and backfills comment authors from existing usernames.